### PR TITLE
Create Matomo users for unknown OIDC users

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -227,6 +227,10 @@ class Controller extends \Piwik\Plugin\Controller
             // user with the remote id is currently not in our database
             if (Piwik::isUserIsAnonymous()) {
                 if ($settings->allowSignup->getValue()) {
+                    if (empty($result->email)) {
+                        throw new Exception(Piwik::translate("LoginOIDC_ExceptionUserNotFoundAndNoEmail"));
+                    }
+
                     $matomoUserLogin = $result->email;
                     // Set an invalid pre-hashed password, to block the user from logging in by password
                     Access::getInstance()->doAsSuperUser(function () use ($matomoUserLogin, $result) {
@@ -241,7 +245,7 @@ class Controller extends \Piwik\Plugin\Controller
                     $this->linkAccount($providerUserId, $matomoUserLogin);
                     $this->signinAndRedirect($user);
                 } else {
-                    throw new Exception(Piwik::translate("LoginOIDC_ExceptionUserNotFound"));
+                    throw new Exception(Piwik::translate("LoginOIDC_ExceptionUserNotFoundAndSignupDisabled"));
                 }
             } else {
                 // link current user with the remote user

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -27,6 +27,13 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     public $disableSuperuser;
 
     /**
+     * Whether new Matomo accounts should be created for unknown users
+     *
+     * @var bool
+     */
+    public $allowSignup;
+
+    /**
      * The name of the oauth provider, which is also shown on the login screen.
      *
      * @var string
@@ -97,6 +104,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     protected function init()
     {
         $this->disableSuperuser = $this->createDisableSuperuserSetting();
+        $this->allowSignup = $this->createAllowSignupSetting();
         $this->authenticationName = $this->createAuthenticationNameSetting();
         $this->authorizeUrl = $this->createAuthorizeUrlSetting();
         $this->tokenUrl = $this->createTokenUrlSetting();
@@ -118,6 +126,20 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         return $this->makeSetting("disableSuperuser", $default = false, FieldConfig::TYPE_BOOL, function(FieldConfig $field) {
             $field->title = Piwik::translate("LoginOIDC_SettingDisableSuperuser");
             $field->description = Piwik::translate("LoginOIDC_SettingDisableSuperuserHelp");
+            $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
+        });
+    }
+
+    /**
+     * Add allowSignup setting.
+     *
+     * @return SystemSetting
+     */
+    private function createAllowSignupSetting() : SystemSetting
+    {
+        return $this->makeSetting("allowSignup", $default = false, FieldConfig::TYPE_BOOL, function(FieldConfig $field) {
+            $field->title = Piwik::translate("LoginOIDC_SettingAllowSignup");
+            $field->description = Piwik::translate("LoginOIDC_SettingAllowSignupHelp");
             $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
         });
     }

--- a/lang/de.json
+++ b/lang/de.json
@@ -30,7 +30,7 @@
         "ExceptionStateMismatch": "OAuth State Fehler.",
         "ExceptionUnknownProvider": "Unbekannter OAuth-Service.",
         "ExceptionInvalidResponse": "Unerwartete Antwort vom OAuth-Service.",
-        "ExceptionUserNotFound": "Benutzer nicht gefunden. Neue Registrierungen über OAuth werden nicht unterstützt.",
+        "ExceptionUserNotFoundAndSignupDisabled": "Benutzer nicht gefunden. Neue Registrierungen über OAuth werden nicht unterstützt.",
         "ExceptionSuperUserOauthDisabled": "OAuth Login für Superuser ist deaktiviert."
     }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -32,7 +32,8 @@
         "ExceptionStateMismatch": "OAuth state mismatch.",
         "ExceptionUnknownProvider": "Unknown OAuth provider.",
         "ExceptionInvalidResponse": "Unexpected response from OAuth service.",
-        "ExceptionUserNotFound": "User not found. OAuth registrations are disabled.",
+        "ExceptionUserNotFoundAndSignupDisabled": "User not found. OAuth registrations are disabled.",
+        "ExceptionUserNotFoundAndNoEmail": "User not found. User could not be created because the OAuth service did not return an email address.",
         "ExceptionSuperUserOauthDisabled": "OAuth login disabled for superusers."
     }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2,6 +2,8 @@
     "LoginOIDC":{
         "SettingDisableSuperuser": "Disable external login for superusers.",
         "SettingDisableSuperuserHelp": "",
+        "SettingAllowSignup": "Create new users when users try to log in with unknown OIDC accounts",
+        "SettingAllowSignupHelp": "",
         "SettingAuthenticationName": "Name",
         "SettingAuthenticationNameHelp": "Name of the authentication source which will be displayed on the login screen.",
         "SettingAuthorizeUrl": "Authorize URL",
@@ -30,7 +32,7 @@
         "ExceptionStateMismatch": "OAuth state mismatch.",
         "ExceptionUnknownProvider": "Unknown OAuth provider.",
         "ExceptionInvalidResponse": "Unexpected response from OAuth service.",
-        "ExceptionUserNotFound": "User not found. OAuth registrations are not supported.",
+        "ExceptionUserNotFound": "User not found. OAuth registrations are disabled.",
         "ExceptionSuperUserOauthDisabled": "OAuth login disabled for superusers."
     }
 }


### PR DESCRIPTION
This is hidden behind a flag, and is currently only tested against Azure AD.
These users do not currently get access to any sites.

Fixes #4.