### PR TITLE
Adjust clientSecret to show as password

### DIFF
--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -262,7 +262,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         return $this->makeSetting("clientSecret", $default = "", FieldConfig::TYPE_STRING, function(FieldConfig $field) {
             $field->title = Piwik::translate("LoginOIDC_SettingClientSecret");
             $field->description = Piwik::translate("LoginOIDC_SettingClientSecretHelp");
-            $field->uiControl = FieldConfig::UI_CONTROL_TEXT;
+            $field->uiControl = FieldConfig::UI_CONTROL_PASSWORD;
         });
     }
 


### PR DESCRIPTION
In SystemSettings.php, adjusting the `uiControl` in `createClientSecretSetting()` to `FieldConfig::UI_CONTROL_PASSWORD`.
This will hide the client secret in the UI.