### PR TITLE
Fix Exception reference

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -9,7 +9,7 @@
 
 namespace Piwik\Plugins\LoginOIDC;
 
-use Exception;
+use \Exception;
 use Piwik\Access;
 use Piwik\Auth;
 use Piwik\Common;

--- a/LoginOIDC.php
+++ b/LoginOIDC.php
@@ -9,7 +9,7 @@
 
 namespace Piwik\Plugins\LoginOIDC;
 
-use Exception;
+use \Exception;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\Db;

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\LoginOIDC;
 
+use \Exception;
 use Piwik\Piwik;
 use Piwik\Settings\FieldConfig;
 use Piwik\Settings\Plugin\SystemSetting;


### PR DESCRIPTION
Update the LoginOIDC Settings show this error:

```json
{result: "error", message: "Class 'Piwik\Plugins\LoginOIDC\Exception' not found"}
message: "Class 'Piwik\Plugins\LoginOIDC\Exception' not found"
result: "error"
```

For the requested URL:

https://analytics.domain.com/index.php?method=CorePluginsAdmin.setSystemSettings&module=API&format=JSON2&idSite=1&period=day&date=today

My Merge Request fix this