### PR TITLE
Fix preserving port in URL

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -236,6 +236,7 @@ class Controller extends \Piwik\Plugin\Controller
 
         $_SESSION['loginoidc_idtoken'] = empty($result->id_token) ? null : $result->id_token;
         $_SESSION['loginoidc_auth'] = true;
+        $_SESSION['loginoidc_refresh_token'] = empty($result->refresh_token) ? null : $result->refresh_token;
 
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_HTTPHEADER, array(

--- a/Url.php
+++ b/Url.php
@@ -78,6 +78,7 @@ class Url
 
         $this->scheme = $urlParts["scheme"];
         $this->host = $urlParts["host"];
+        $this->port = $urlParts["port"];
         $this->path = $urlParts["path"];
 
         if (isset($urlParts["query"])) { 


### PR DESCRIPTION
At this moment, if the Logout URL contains a port, it is lost, which causes problems.