### PR TITLE
Handle if user attributes are a property of returned user info

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -274,6 +274,10 @@ class Controller extends \Piwik\Plugin\Controller
 
         if (empty($user)) {
             if (Piwik::isUserIsAnonymous()) {
+                // Handle if user attributes are a property of $result.
+                if(!isset($result->email) && (isset($result->attributes->email) || isset($result->attributes->mail))) {
+                    $result = $result->attributes;
+                }
                 // user with the remote id is currently not in our database
                 $this->signupUser($settings, $providerUserId, $result->email);
             } else {


### PR DESCRIPTION
Do not fail on implementations that return attributes as a property of the user info.  Our CAS-based OIDC service returns the result like this:
```
result=stdClass Object
(
    [service] => https://mymatomosite.somedomain.com/index.php?module=LoginOIDC&action=callback&provider=oidc
    [attributes] => stdClass Object
        (
            [mail] => myemail@somesomain.com.xxxyyyzzz
...
        )
     [id] => myusername
     [client_id] => myclientid

```