### PR TITLE
Fix logout url to the oidc provider

### DIFF
--- a/LoginOIDC.php
+++ b/LoginOIDC.php
@@ -146,8 +146,8 @@ class LoginOIDC extends \Piwik\Plugin
         $endSessionUrl = $settings->endSessionUrl->getValue();
         if (!empty($endSessionUrl) && $_SESSION["loginoidc_auth"]) {
             $endSessionUrl = new Url($endSessionUrl);
-            if (isset($_SESSION[loginoidc_idtoken])) {
-                $endSessionUrl->setQueryParameter("id_token_hint", $_SESSION[loginoidc_idtoken]);
+            if (isset($_SESSION["loginoidc_idtoken"])) {
+                $endSessionUrl->setQueryParameter("id_token_hint", $_SESSION["loginoidc_idtoken"]);
             }
             $originalLogoutUrl = Config::getInstance()->General['login_logout_url'];
             if ($originalLogoutUrl) {


### PR DESCRIPTION
I get an error when I try to log out. Due to incorrect access to an array element.
P.S I am using Keycloak provider

<img width="500" alt="Снимок экрана 2022-03-11 в 09 52 49" src="https://user-images.githubusercontent.com/21226623/157818790-f92bfc4a-ab2d-4594-ac0a-47a77e18ad23.png">


