### PR TITLE
Role-based authorization

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -232,10 +232,11 @@ class Controller extends \Piwik\Plugin\Controller
         if (empty($result) || empty($result->access_token)) {
             throw new Exception(Piwik::translate("LoginOIDC_ExceptionInvalidResponse"));
         }
-        $access_token=json_decode(base64_decode(str_replace('_', '/', str_replace('-','+',explode('.', $result->access_token)[1]))));
-        $has_correct_role = in_array($settings->allowedRole->getValue(), $access_token->roles);
-        if (!empty($settings->allowedRole->getValue()) && !$has_correct_role) {
-            throw new Exception(Piwik::translate("LoginOIDC_ExceptionInvalidResponse"));
+        if (!empty($settings->allowedRole->getValue())) {
+            $access_token=json_decode(base64_decode(str_replace('_', '/', str_replace('-','+',explode('.', $result->access_token)[1]))));
+            if (empty($access_token->roles) || !in_array($settings->allowedRole->getValue(), $access_token->roles)) {
+                throw new Exception(Piwik::translate("LoginOIDC_ExceptionInvalidResponse"));
+            }
         }
         $_SESSION['loginoidc_idtoken'] = empty($result->id_token) ? null : $result->id_token;
         $_SESSION['loginoidc_auth'] = true;

--- a/Controller.php
+++ b/Controller.php
@@ -229,11 +229,14 @@ class Controller extends \Piwik\Plugin\Controller
         $response = curl_exec($curl);
         curl_close($curl);
         $result = json_decode($response);
-
         if (empty($result) || empty($result->access_token)) {
             throw new Exception(Piwik::translate("LoginOIDC_ExceptionInvalidResponse"));
         }
-
+        $access_token=json_decode(base64_decode(str_replace('_', '/', str_replace('-','+',explode('.', $result->access_token)[1]))));
+        $has_correct_role = in_array($settings->allowedRole->getValue(), $access_token->roles);
+        if (!empty($settings->allowedRole->getValue()) && !$has_correct_role) {
+            throw new Exception(Piwik::translate("LoginOIDC_ExceptionInvalidResponse"));
+        }
         $_SESSION['loginoidc_idtoken'] = empty($result->id_token) ? null : $result->id_token;
         $_SESSION['loginoidc_auth'] = true;
 

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -119,6 +119,13 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     public $scope;
 
     /**
+     * The allowedRole.
+     *
+     * @var string
+     */
+    public $allowedRole;
+
+    /**
      * The optional redirect uri override.
      *
      * @var string
@@ -153,6 +160,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         $this->clientId = $this->createClientIdSetting();
         $this->clientSecret = $this->createClientSecretSetting();
         $this->scope = $this->createScopeSetting();
+        $this->allowedRole = $this->createAllowedRoleSetting();
         $this->redirectUriOverride = $this->createRedirectUriOverrideSetting();
         $this->allowedSignupDomains = $this->createAllowedSignupDomainsSetting();
     }
@@ -368,6 +376,20 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
             $field->title = Piwik::translate("LoginOIDC_SettingRedirectUriOverride");
             $field->description = Piwik::translate("LoginOIDC_SettingRedirectUriOverrideHelp");
             $field->uiControl = FieldConfig::UI_CONTROL_URL;
+        });
+    }
+
+    /**
+     * Add allowed signup domains setting.
+     *
+     * @return SystemSetting
+     */
+    private function createAllowedRoleSetting() : SystemSetting
+    {
+        return $this->makeSetting("allowedRole", $default = "", FieldConfig::TYPE_STRING, function(FieldConfig $field) {
+            $field->title = Piwik::translate("LoginOIDC_SettingAllowedRole");
+            $field->description = Piwik::translate("LoginOIDC_SettingAllowedRoleHelp");
+            $field->uiControl = FieldConfig::UI_CONTROL_TEXT;
         });
     }
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -28,6 +28,8 @@
         "SettingRedirectUriOverrideHelp": "In manchen Fällen ist es nützlich, die Redirect URI, die an den OpenID Connect Provider übergeben wird, zu überschreiben. Bei Unklarheit sollte dieses Feld freigelassen werden.",
         "SettingAllowedSignupDomains": "Erlaubte Domains für Accounterstellung",
         "SettingAllowedSignupDomainsHelp": "Wenn das Feld freigelassen wird, können sich Benutzer mit beliebiger E-Mail Adresse registrieren. Mehrere Domains können in separaten Zeilen angegeben werden.",
+        "SettingAllowedRole": "Restrict user login with specific role",
+        "SettingAllowedRoleHelp": "z.B. matomo-user",
         "SettingAutoLinking": "Aktiviere Auto Linking",
         "SettingAutoLinkingHelp": "Aktiviert Auto Linking von Accounts, die die selbe User ID in Matomo und dem OpenID Connect Provider haben.",
         "OpenIDConnect": "OpenID Connect",

--- a/lang/en.json
+++ b/lang/en.json
@@ -28,6 +28,8 @@
         "SettingScopeHelp": "e.g. 'openid' or 'openid email'",
         "SettingRedirectUriOverride": "Redirect URI override",
         "SettingRedirectUriOverrideHelp": "In some cases it might be useful to manipulate the redirect uri which is given to the OpenID Connect provider. If you are unsure, just leave this field empty.",
+        "SettingAllowedRole": "Restrict user login with specific role",
+        "SettingAllowedRoleHelp": "e.g. matomo-user",
         "SettingAllowedSignupDomains": "Restrict user creation to domains",
         "SettingAllowedSignupDomainsHelp": "List of email domains which should be allowed to create new accounts. Multiple domains have to be separated by line breaks. When empty, any email domain will be accepted.",
         "SettingAutoLinking": "Enable auto linking",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -30,6 +30,8 @@
         "SettingRedirectUriOverrideHelp": "Dans certains cas, il peut être pratique de redéfinir l'URI de redirection qui est transmise au fournisseur OpenID Connect. Si vous êtes n'êtes pas sûr, laissez ce champ vide.",
         "SettingAllowedSignupDomains": "Limiter la création d'utilisateurs aux domaines",
         "SettingAllowedSignupDomainsHelp": "",
+        "SettingAllowedRole": "Limiter la connexion de l'utilisateur avec un rôle spécifique",
+        "SettingAllowedRoleHelp": "ex. matomo-user",
         "OpenIDConnect": "OpenID Connect",
         "OIDCIntro": "Ceci vous permet de vous connecter à Matomo en utilisant un service d'authentification externe.",
         "AccountLinked": "Votre compte est actuellement lié (Identifiant du compte utilisateur distant : %1$s).",


### PR DESCRIPTION
A setting is added to check whether the user has a specific role e.g. matomo-user in the access token. This is needed to check if this user is allowed to login in to matomo in an environment where not all users are allowed to login in all applications.
