### PR TITLE
Adds a setting to define the key used to get an user's email

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -276,7 +276,7 @@ class Controller extends \Piwik\Plugin\Controller
             if (Piwik::isUserIsAnonymous()) {
                 // user with the remote id is currently not in our database
                 $emailKey = $settings->emailKey->getValue();
-                $this->signupUser($settings, $providerUserId, $result->{$email});
+                $this->signupUser($settings, $providerUserId, $result->{$emailKey});
             } else {
                 // link current user with the remote user
                 $this->linkAccount($providerUserId);

--- a/Controller.php
+++ b/Controller.php
@@ -275,7 +275,8 @@ class Controller extends \Piwik\Plugin\Controller
         if (empty($user)) {
             if (Piwik::isUserIsAnonymous()) {
                 // user with the remote id is currently not in our database
-                $this->signupUser($settings, $providerUserId, $result->email);
+                $emailKey = $settings->emailKey->getValue();
+                $this->signupUser($settings, $providerUserId, $result->{$email});
             } else {
                 // link current user with the remote user
                 $this->linkAccount($providerUserId);

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -105,6 +105,12 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     public $userinfoId;
 
     /**
+     * The name of the field used to retrieve the user's email
+     * 
+     * @var string
+     */
+    public $emailKey;
+    /**
      * The client id given by the provider.
      *
      * @var string

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -158,6 +158,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         $this->userinfoUrl = $this->createUserinfoUrlSetting();
         $this->endSessionUrl = $this->createEndSessionUrlSetting();
         $this->userinfoId = $this->createUserinfoIdSetting();
+        $this->emailKey = $this->createEmailKeySetting();
         $this->clientId = $this->createClientIdSetting();
         $this->clientSecret = $this->createClientSecretSetting();
         $this->scope = $this->createScopeSetting();
@@ -334,6 +335,20 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
             $field->description = Piwik::translate("LoginOIDC_SettingUserinfoIdHelp");
             $field->uiControl = FieldConfig::UI_CONTROL_TEXT;
             $field->validators[] = new NotEmpty();
+        });
+    }
+
+    /**
+     * Add email key setting.
+     *
+     * @return SystemSetting
+     */
+    private function createEmailKeySetting() : SystemSetting
+    {
+        return $this->makeSetting("emailKey", $default = "email", FieldConfig::TYPE_STRING, function(FieldConfig $field) {
+            $field->title = Piwik::translate("LoginOIDC_SettingEmailKey");
+            $field->description = Piwik::translate("LoginOIDC_SettingEmailKeyHelp");
+            $field->uiControl = FieldConfig::UI_CONTROL_TEXT;
         });
     }
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -20,6 +20,8 @@
         "SettingEndSessionUrlHelp": "Nach dem Logout wird der Benutzer zu dieser URL weitergeleitet, damit die Session beim Provider beendet wird. Bei Unklarheit sollte dieses Feld freigelassen werden.",
         "SettingUserinfoId": "Userinfo ID",
         "SettingUserinfoIdHelp": "Name des Feldes, in dem die Benutzer-ID enthalten ist. Normalerweise, für OpenID Connect Dienste wie Auth0, ist das 'sub'. Github gibt die eindeutige Benutzer-ID in dem Feld 'id' an.",
+        "SettingEmailKey": "Email key",
+        "SettingEmailKeyHelp": "Schlüssel des Objekts User info, das die E-Mail des Benutzers enthält.",
         "SettingClientId": "Client ID",
         "SettingClientIdHelp": "",
         "SettingClientSecret": "Client Secret",

--- a/lang/de.json
+++ b/lang/de.json
@@ -21,7 +21,7 @@
         "SettingUserinfoId": "Userinfo ID",
         "SettingUserinfoIdHelp": "Name des Feldes, in dem die Benutzer-ID enthalten ist. Normalerweise, für OpenID Connect Dienste wie Auth0, ist das 'sub'. Github gibt die eindeutige Benutzer-ID in dem Feld 'id' an.",
         "SettingEmailKey": "Email key",
-        "SettingEmailKeyHelp": "Schlüssel des Objekts User info, das die E-Mail des Benutzers enthält.",
+        "SettingEmailKeyHelp": "Schlüssel, der die E-Mail in den Benutzerinformationen angibt.",
         "SettingClientId": "Client ID",
         "SettingClientIdHelp": "",
         "SettingClientSecret": "Client Secret",

--- a/lang/en.json
+++ b/lang/en.json
@@ -22,6 +22,8 @@
         "SettingEndSessionUrlHelp": "After logging out, the user is redirected to this URL to end the session at the provider. If you are unsure, just leave this field empty.",
         "SettingUserinfoId": "Userinfo ID",
         "SettingUserinfoIdHelp": "Name of the unique user id field in the userinfo response. Usually for OpenID Connect services like Auth0 this is 'sub'. Github provides the user id in 'id'.",
+        "SettingEmailKey": "Email key",
+        "SettingEmailKeyHelp": "Key of the User info object containing the user's email.",
         "SettingClientId": "Client ID",
         "SettingClientIdHelp": "",
         "SettingClientSecret": "Client Secret",

--- a/lang/en.json
+++ b/lang/en.json
@@ -23,7 +23,7 @@
         "SettingUserinfoId": "Userinfo ID",
         "SettingUserinfoIdHelp": "Name of the unique user id field in the userinfo response. Usually for OpenID Connect services like Auth0 this is 'sub'. Github provides the user id in 'id'.",
         "SettingEmailKey": "Email key",
-        "SettingEmailKeyHelp": "Key of the User info object containing the user's email.",
+        "SettingEmailKeyHelp": "Key that specifies the email in the user information.",
         "SettingClientId": "Client ID",
         "SettingClientIdHelp": "",
         "SettingClientSecret": "Client Secret",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -20,6 +20,8 @@
         "SettingEndSessionUrlHelp": "",
         "SettingUserinfoId": "ID Userinfo",
         "SettingUserinfoIdHelp": "Nom du champ de l'identifiant unique utilisateur dans la réponse 'userinfo'. Habituellement, pour les services de connexion OpenID Connect comme Auth0, il s'agit de 'sub'. Github fourni l'identifiant utilisateur avec 'id'.",
+        "SettingEmailKey": "Clé de l'email",
+        "SettingEmailKeyHelp": "Clé de l'objet utilisateur indiquant l'email.",
         "SettingClientId": "Client ID",
         "SettingClientIdHelp": "",
         "SettingClientSecret": "Client Secret",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -21,7 +21,7 @@
         "SettingUserinfoId": "ID Userinfo",
         "SettingUserinfoIdHelp": "Nom du champ de l'identifiant unique utilisateur dans la réponse 'userinfo'. Habituellement, pour les services de connexion OpenID Connect comme Auth0, il s'agit de 'sub'. Github fourni l'identifiant utilisateur avec 'id'.",
         "SettingEmailKey": "Clé de l'email",
-        "SettingEmailKeyHelp": "Clé de l'objet utilisateur indiquant l'email.",
+        "SettingEmailKeyHelp": "Clé indiquant l'email dans les informations utilisateur.",
         "SettingClientId": "Client ID",
         "SettingClientIdHelp": "",
         "SettingClientSecret": "Client Secret",


### PR DESCRIPTION
My company use the field `userEmail` instead of `email` in the user resource. I need to specify it to be able to create users when they try to login for the first time using this plugin.