### PR TITLE
Hide password login

### DIFF
--- a/LoginOIDC.php
+++ b/LoginOIDC.php
@@ -75,7 +75,12 @@ class LoginOIDC extends \Piwik\Plugin
      */
     public function getStylesheetFiles(array &$files)
     {
+        $settings = new SystemSettings();
+        $hidePasswordLogin = $settings->hidePasswordLogin->getValue();
         $files[] = "plugins/LoginOIDC/stylesheets/loginMod.css";
+        if ($hidePasswordLogin) {
+            $files[] = "plugins/LoginOIDC/stylesheets/loginModHidePwLogin.css";
+        }
     }
 
     /**

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -42,6 +42,13 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     public $disableDirectLoginUrl;
 
     /**
+     * Whether to hide standard password login form.
+     *
+     * @var bool
+     */
+    public $hidePasswordLogin;
+
+    /**
      * Whether new Matomo accounts should be created for unknown users
      *
      * @var bool
@@ -149,6 +156,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         $this->disableSuperuser = $this->createDisableSuperuserSetting();
         $this->disablePasswordConfirmation = $this->createDisablePasswordConfirmationSetting();
         $this->disableDirectLoginUrl = $this->createDisableDirectLoginUrlSetting();
+        $this->hidePasswordLogin = $this->createHidePasswordLoginSetting();
         $this->allowSignup = $this->createAllowSignupSetting();
         $this->bypassTwoFa = $this->createBypassTwoFaSetting();
         $this->autoLinking = $this->createAutoLinkingSetting();
@@ -203,6 +211,20 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         return $this->makeSetting("disableDirectLoginUrl", $default = true, FieldConfig::TYPE_BOOL, function(FieldConfig $field) {
             $field->title = Piwik::translate("LoginOIDC_SettingDisableDirectLoginUrl");
             $field->description = Piwik::translate("LoginOIDC_SettingDisableDirectLoginUrlHelp");
+            $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
+        });
+    }
+    
+    /**
+     * Add hide password login setting.
+     *
+     * @return SystemSetting
+     */
+    private function createHidePasswordLoginSetting() : SystemSetting
+    {
+        return $this->makeSetting("hidePasswordLogin", $default = false, FieldConfig::TYPE_BOOL, function(FieldConfig $field) {
+            $field->title = Piwik::translate("LoginOIDC_SettingHidePasswordLogin");
+            $field->description = Piwik::translate("LoginOIDC_SettingHidePasswordLoginHelp");
             $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
         });
     }

--- a/lang/de.json
+++ b/lang/de.json
@@ -6,6 +6,7 @@
         "SettingDisablePasswordConfirmationHelp": "Einige administrative Aufgaben erfordern eine explizite Bestätigung des Benutzerpasswortes. Wenn Benutzer ohne gesetztes Passwort Matomo benutzen kann über diese Einstellung der Bestätigungsdialog überspringbar gemacht werden.",
         "SettingDisableDirectLoginUrl": "Deaktiviere direkten Login Link",
         "SettingDisableDirectLoginUrlHelp": "Wenn der Haken gesetzt ist muss der Login über die Login-Seite initiiert werden, anderenfalls lässt sich die Loginschaltfläche auch von dritten Seiten einbinden.",
+        "SettingHidePasswordLogin": "Wenn diese Option aktiviert ist, wird die Standard-Anmeldeaufforderung für Benutzername und Passwort ausgeblendet.",
         "SettingAllowSignup": "Erstelle automatisch einen neuen Account, wenn sich ein unbekannter neuer Benutzer einloggt",
         "SettingAllowSignupHelp": "",
         "SettingAuthenticationName": "Name",

--- a/lang/en.json
+++ b/lang/en.json
@@ -6,6 +6,7 @@
         "SettingDisablePasswordConfirmationHelp": "Certain administrational tasks require a password confirmation. When administrators are using this plugin and do not have a password they could confirm, this option can be used to skip the dialogue, when signed in via LoginOIDC",
         "SettingDisableDirectLoginUrl": "Disable direct login url",
         "SettingDisableDirectLoginUrlHelp": "When checked, users have to inititate the login via the Matomo login page. Otherwise the login button can be embedded in third-party services.",
+        "SettingHidePasswordLogin": "When checked, will hide standard username and password login prompt.",
         "SettingAllowSignup": "Create new users when users try to log in with unknown OIDC accounts",
         "SettingAllowSignupHelp": "",
         "SettingBypassTwoFa": "Disable second factor when sign in with OIDC",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -4,6 +4,7 @@
         "SettingDisableSuperuserHelp": "",
         "SettingDisableDirectLoginUrl": "Désactiver l'url de connexion directe",
         "SettingDisableDirectLoginUrlHelp": "",
+        "SettingHidePasswordLogin": "Lorsque cette option est cochée, elle masque l'invite de connexion standard pour le nom d'utilisateur et le mot de passe.",
         "SettingAllowSignup": "Créer une nouveau compte utilisateur quand les utilisateurs tentent de se connecter avec un compte OIDC inconnu",
         "SettingAllowSignupHelp": "",
         "SettingBypassTwoFa": "Désactiver le 2è facteur lors d'une connexion avec OIDC",

--- a/stylesheets/loginModHidePwLogin.css
+++ b/stylesheets/loginModHidePwLogin.css
@@ -1,0 +1,7 @@
+.loginForm #login_form {
+    display: none;
+}
+
+.loginForm #nav {
+    display: none;
+}


### PR DESCRIPTION
Allows admins to use

[LoginOIDC]
hidePasswordLogin = 1

to hide standard password login prompt and only show OIDC button (to reduce user confusion):

<img width="674" alt="Screen Shot 2022-11-23 at 11 06 47 AM" src="https://user-images.githubusercontent.com/106999752/203628000-41dac083-d961-479e-9f09-8f04b3bf9780.png">
