### PR TITLE
Hacky fix for loginOIDC login redirect loop

### DIFF
--- a/LoginOIDC.php
+++ b/LoginOIDC.php
@@ -36,8 +36,32 @@ class LoginOIDC extends \Piwik\Plugin
             "Template.loginNav" => "renderLoginOIDCMod",
             "Template.confirmPasswordContent" => "renderConfirmPasswordMod",
             "Login.logout" => "logoutMod",
-            "Login.userRequiresPasswordConfirmation" => "userRequiresPasswordConfirmation"
+            "Login.userRequiresPasswordConfirmation" => "userRequiresPasswordConfirmation",
+            "Request.dispatch" => array(
+                "before" => true,
+                "function" => "checkLogin",
+            ),
         );
+    }
+
+    /**
+     * Redirects default login action to LoginOIDC UI instead of bouncing it around Login -> LoginOIDC -> Login -> ...
+     * 
+     * @param string $pluginName
+     * @param string $methodName
+     * @param array &$parameters
+     * 
+     * @return void
+     */
+    public function checkLogin($pluginName, $methodName, &$parameters): void
+    {
+        if ($pluginName == "Login" && $methodName == "login") {
+            $baseUrl = \Piwik\Url::getCurrentUrlWithoutFileName();
+            $loginUrl = $baseUrl . 'index.php';
+            \Piwik\Url::redirectToUrl($loginUrl);
+            exit();
+        }
+        return;
     }
 
     /**


### PR DESCRIPTION
This commit fixes #81 login redirection loop on Docker Matomo 4.12.3 + LoginOIDC between Login & LoginOIDC plugins.

Screenshot is taken using both #82 and #83

<img width="757" alt="Screen Shot 2022-11-23 at 4 26 17 PM" src="https://user-images.githubusercontent.com/106999752/203668297-62a32ddd-a7a3-4525-a32a-52da6dddb49c.png">
