### PR TITLE
 Add an internal URL setting for OIDC servers behind the same reverse proxy

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -225,7 +225,19 @@ class Controller extends \Piwik\Plugin\Controller
             "User-Agent: LoginOIDC-Matomo-Plugin"
         ));
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curl, CURLOPT_URL, $settings->tokenUrl->getValue());
+
+        $tokenURL = parse_url($settings->tokenUrl->getValue());
+
+        if (!empty($settings->internalUrl->getValue())){
+          $internalURL = parse_url($settings->internalUrl->getValue());
+
+          $tokenUrlValue = str_replace($tokenURL["scheme"], $internalURL["scheme"], $settings->tokenUrl->getValue());
+          $tokenUrlValue = str_replace($tokenURL["port"], "", $tokenUrlValue);
+          $tokenUrlValue = str_replace($tokenURL["host"], $internalURL["host"] . ":" . $internalURL["port"], $tokenUrlValue);
+        }
+
+        curl_setopt($curl, CURLOPT_URL, $tokenUrlValue);
+
         // request authorization token
         $response = curl_exec($curl);
         curl_close($curl);
@@ -245,7 +257,19 @@ class Controller extends \Piwik\Plugin\Controller
             "User-Agent: LoginOIDC-Matomo-Plugin"
         ));
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curl, CURLOPT_URL, $settings->userinfoUrl->getValue());
+
+        $userinfoURL = parse_url($settings->userinfoUrl->getValue());
+
+        if (!empty($settings->internalUrl->getValue())){
+          $internalURL = parse_url($settings->internalUrl->getValue());
+
+          $userInfoURLValue = str_replace($tokenURL["scheme"], $internalURL["scheme"], $settings->userinfoUrl->getValue());
+          $userInfoURLValue = str_replace($tokenURL["port"], "", $userInfoURLValue);
+          $userInfoURLValue = str_replace($tokenURL["host"], $internalURL["host"] . ":" . $internalURL["port"], $userInfoURLValue);
+        }
+
+        curl_setopt($curl, CURLOPT_URL, $userInfoURLValue);
+
         // request remote userinfo and remote user id
         $response = curl_exec($curl);
         curl_close($curl);

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -98,6 +98,13 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     public $endSessionUrl;
 
     /**
+     * The internal url if the OIDC provider is behind a reverse proxy.
+     *
+     * @var string
+     */
+    public $internalUrl;
+
+    /**
      * The name of the unique user id field in $userinfoUrl response.
      *
      * @var string
@@ -157,6 +164,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         $this->tokenUrl = $this->createTokenUrlSetting();
         $this->userinfoUrl = $this->createUserinfoUrlSetting();
         $this->endSessionUrl = $this->createEndSessionUrlSetting();
+        $this->internalUrl = $this->createInternalUrlSetting();
         $this->userinfoId = $this->createUserinfoIdSetting();
         $this->clientId = $this->createClientIdSetting();
         $this->clientSecret = $this->createClientSecretSetting();
@@ -318,6 +326,20 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         return $this->makeSetting("endSessionUrl", $default = "", FieldConfig::TYPE_STRING, function(FieldConfig $field) {
             $field->title = Piwik::translate("LoginOIDC_SettingEndSessionUrl");
             $field->description = Piwik::translate("LoginOIDC_SettingEndSessionUrlHelp");
+            $field->uiControl = FieldConfig::UI_CONTROL_URL;
+        });
+    }
+
+    /**
+     * Add internal url setting.
+     * 
+     * @return SystemSetting
+     */
+    private function createInternalUrlSetting() : SystemSetting
+    {
+        return $this->makeSetting("internalUrl", $default = "", FieldConfig::TYPE_STRING, function(FieldConfig $field) {
+            $field->title = Piwik::translate("LoginOIDC_SettingInternalUrl");
+            $field->description = Piwik::translate("LoginOIDC_SettingInternalUrlHelp");
             $field->uiControl = FieldConfig::UI_CONTROL_URL;
         });
     }

--- a/lang/de.json
+++ b/lang/de.json
@@ -20,6 +20,8 @@
         "SettingEndSessionUrlHelp": "Nach dem Logout wird der Benutzer zu dieser URL weitergeleitet, damit die Session beim Provider beendet wird. Bei Unklarheit sollte dieses Feld freigelassen werden.",
         "SettingUserinfoId": "Userinfo ID",
         "SettingUserinfoIdHelp": "Name des Feldes, in dem die Benutzer-ID enthalten ist. Normalerweise, für OpenID Connect Dienste wie Auth0, ist das 'sub'. Github gibt die eindeutige Benutzer-ID in dem Feld 'id' an.",
+        "SettingInternalUrl": "Interne URL",
+        "SettingInternalUrlHelp": "Die URL, ist für den Fall das der OIDC Provider hinter dem selben Reverse Proxy wie Matomo läuft. Wenn nicht gesetzt, werden sowohl im Client als auch im Server die selben URLs verwendet.",
         "SettingClientId": "Client ID",
         "SettingClientIdHelp": "",
         "SettingClientSecret": "Client Secret",

--- a/lang/en.json
+++ b/lang/en.json
@@ -22,6 +22,8 @@
         "SettingEndSessionUrlHelp": "After logging out, the user is redirected to this URL to end the session at the provider. If you are unsure, just leave this field empty.",
         "SettingUserinfoId": "Userinfo ID",
         "SettingUserinfoIdHelp": "Name of the unique user id field in the userinfo response. Usually for OpenID Connect services like Auth0 this is 'sub'. Github provides the user id in 'id'.",
+        "SettingInternalUrl": "Internal URL",
+        "SettingInternalUrlHelp": "The URL is used in case the OIDC Provider is behind the same reverse proxy as Matomo. If not set, the same URLs will be used in both the client and the server.",
         "SettingClientId": "Client ID",
         "SettingClientIdHelp": "",
         "SettingClientSecret": "Client Secret",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -20,6 +20,8 @@
         "SettingEndSessionUrlHelp": "",
         "SettingUserinfoId": "ID Userinfo",
         "SettingUserinfoIdHelp": "Nom du champ de l'identifiant unique utilisateur dans la réponse 'userinfo'. Habituellement, pour les services de connexion OpenID Connect comme Auth0, il s'agit de 'sub'. Github fourni l'identifiant utilisateur avec 'id'.",
+        "SettingInternalUrl": "URL interne",
+        "SettingInternalUrlHelp": "L'URL est utilisée dans le cas où le fournisseur OIDC est derrière le même proxy inverse que Matomo. Si non défini, les mêmes URL seront utilisées à la fois dans le client et dans le serveur.",
         "SettingClientId": "Client ID",
         "SettingClientIdHelp": "",
         "SettingClientSecret": "Client Secret",


### PR DESCRIPTION
A new setting for the internal URL has been added in this pull request. This setting is useful if the OIDC provider runs behind the same reverse proxy as Matomo. In such cases, it may be necessary to specify the internal URL of the OIDC provider in order to correctly route internal cURL requests.

The changes include:
1. Adding a new setting internalUrl in the LoginOIDC plugin. This setting allows the user to specify the internal URL of the OIDC provider.
2. Changing the tokenUrl and userinfoUrl settings to include the internalUrl if it is set. If the internalUrl is set, the tokenUrl and userinfoUrl will be changed to use the internalUrl's scheme, host and port.
3. Add translations for the internalUrl setting in the language files.

These changes should make it easier for Matomo users who use an OIDC provider behind the same reverse proxy to set up their configuration correctly.

I look forward to any feedback. Please let me know if there are any additional adjustments I should make to meet your requirements.
