### PR TITLE
Avoid conflict between Auth methods

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -11,7 +11,6 @@ namespace Piwik\Plugins\LoginOIDC;
 
 use Exception;
 use Piwik\Access;
-use Piwik\Auth;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;


### PR DESCRIPTION
Resolve:

```
ERROR Piwik\FrontController Uncaught exception: Error:
Call to undefined method Piwik\Plugins\Login\Auth::setForceLogin()
in /srv/www/matomo/plugins/LoginOIDC/Controller.php:431
```

It seems it loaded the methods from Piwik\Auth instead of Piwik\Plugins\LoginOIDC\OIDCAuth - which worked for getLogin() (which exists in both files), but failed at setForceLogin() (which only exists in the latter).